### PR TITLE
feat(report): Correctly report errors without associated requests 

### DIFF
--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -1,4 +1,4 @@
-package sentry
+package sentryecho
 
 import (
 	"net/http"

--- a/pkg/handler_test.go
+++ b/pkg/handler_test.go
@@ -1,4 +1,4 @@
-package sentry
+package sentryecho
 
 import (
 	"errors"

--- a/pkg/logger.go
+++ b/pkg/logger.go
@@ -1,4 +1,4 @@
-package sentry
+package sentryecho
 
 import (
 	"github.com/labstack/echo"

--- a/pkg/logger_test.go
+++ b/pkg/logger_test.go
@@ -1,4 +1,4 @@
-package sentry
+package sentryecho
 
 import (
 	"testing"

--- a/pkg/sentry/client.go
+++ b/pkg/sentry/client.go
@@ -1,4 +1,4 @@
-package client
+package sentry
 
 import (
 	"net/http"

--- a/pkg/sentry/client_test.go
+++ b/pkg/sentry/client_test.go
@@ -1,4 +1,4 @@
-package client
+package sentry
 
 import (
 	"errors"


### PR DESCRIPTION
Don't attempt to include the HTTP request if it wasn't passed to `report`.