### PR TITLE
chore(circleci): remove no longer needed github access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ jobs:
       - image: circleci/golang:1.10.7
     working_directory: /go/src/github.com/lob/sentry-echo
     steps:
-      - run:
-          name: Configure Github Access
-          command: echo "machine github.com login $GITHUB_USER password $GITHUB_PASS" >> ~/.netrc
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
## What
Remove GitHub access configuration in CircleCI

## Why
Now that logger-go is public, there's no need for this.