### PR TITLE
fix(sentry): unwrap errors before reporting them to sentry

### DIFF
--- a/pkg/sentry/client.go
+++ b/pkg/sentry/client.go
@@ -60,7 +60,7 @@ func NewWithOptions(options Options) (Sentry, error) {
 // then the error is lost.
 func (c *Sentry) Report(err error, req *http.Request) (string, chan error) {
 	captured := []raven.Interface{
-		raven.NewException(err, raven.GetOrNewStacktrace(err, 0, 2, nil)),
+		raven.NewException(errors.Cause(err), raven.GetOrNewStacktrace(err, 0, 2, nil)),
 	}
 	if req != nil {
 		captured = append(captured, raven.NewHttp(c.sanitizeRequest(req)))


### PR DESCRIPTION
## What
- [x] Unwrap errors using [`errors.Cause(err)`](https://godoc.org/github.com/pkg/errors#Cause) before reporting them to Sentry

## Why
Unwrapping the errors allows us to get information about the actual error we are returning instead of the `errors.withStack{}` struct.

## In-depth explanation
### Context
Errors in earlier (and current) versions of Go was somewhat lacking and didn't have the concept of a stacktrace. Therefore when reporting the error to Sentry we would get the stack trace of when the error was handled (usually the Sentry error handler itself) and not where the error actually came from (the stack trace we care about). In order to solve this problem the Go community created [`pkg/errors`](https://github.com/pkg/errors/) which allows you to add extra context metadata to the error (such as a real stack trace of where the error happened). This comes handy as we can extract that stack trace and report it to Sentry in order to get a better picture of where the error happened (this is still not a perfect solution because we get the stack trace of the [`errors.Wrap`](https://godoc.org/github.com/pkg/errors#Wrap) call and not the one from the error itself but they should be next to each other).
### The problem
By using the `pkg/errors` error instead of the raw error we introduce some misdirection as we actually end up reporting the wrapped error and not the actual error to sentry. When [sentry calls the `.Error()` function on the error to get its message](https://github.com/getsentry/raven-go/blob/0b712ea9bd5b81c5f4207c0afe6c2cd558b04963/exception.go#L12) it will get the message from the wrapper error rather than the error itself. This causes problems as Sentry bundles up errors based on the error message, and the wrapped errors [all start the same](https://github.com/pkg/errors/blob/master/errors.go#L241) depending on the type of `pkg/errors` it is.

### Solution
The solution is simple, instead of reporting the wrapper error we can just report the unwrapped error which will be formatted and bundled as expected.