### PR TITLE
feat(errors): allow surfacing custom error message in HTTP responses

### DIFF
--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -1,6 +1,7 @@
 package sentryecho
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo"
@@ -33,7 +34,7 @@ func (h *handler) handleError(err error, c echo.Context) {
 
 	if he, ok := err.(*echo.HTTPError); ok {
 		code = he.Code
-		msg = http.StatusText(code)
+		msg = fmt.Sprintf("%v", he.Message)
 	}
 
 	if code == http.StatusInternalServerError {

--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -8,20 +8,36 @@ import (
 	logger "github.com/lob/logger-go"
 )
 
-// HTTPErrorReporter defines an interface for reporting errors associated with a Request
+// Options defines a struct that allows you to modify the behavior of how errors are reported.
+type Options struct {
+	Reporter                  HTTPErrorReporter
+	EnableCustomErrorMessages bool
+}
+
+// HTTPErrorReporter defines an interface for reporting errors associated with a Request.
 type HTTPErrorReporter interface {
 	Report(error, *http.Request) (string, chan error)
 }
 
 type handler struct {
-	reporter HTTPErrorReporter
+	reporter            HTTPErrorReporter
+	customErrorMessages bool
 }
 
-// RegisterErrorHandler registers an error reporter as the HTTP Error Handler for Echo
-func RegisterErrorHandler(e *echo.Echo, reporter HTTPErrorReporter) {
-	h := handler{reporter}
+// RegisterErrorHandlerWithOptions registers an error reporter as the HTTP Error Handler
+// for Echo and provides options on how the error should be treated.
+func RegisterErrorHandlerWithOptions(e *echo.Echo, options Options) {
+	h := handler{
+		reporter:            options.Reporter,
+		customErrorMessages: options.EnableCustomErrorMessages,
+	}
 
 	e.HTTPErrorHandler = h.handleError
+}
+
+// RegisterErrorHandler registers an error reporter as the HTTP Error Handler for Echo.
+func RegisterErrorHandler(e *echo.Echo, reporter HTTPErrorReporter) {
+	RegisterErrorHandlerWithOptions(e, Options{Reporter: reporter})
 }
 
 // handleError is an Echo error handler that uses HTTP errors accordingly, and any
@@ -34,7 +50,11 @@ func (h *handler) handleError(err error, c echo.Context) {
 
 	if he, ok := err.(*echo.HTTPError); ok {
 		code = he.Code
-		msg = fmt.Sprintf("%v", he.Message)
+		if h.customErrorMessages {
+			msg = fmt.Sprintf("%v", he.Message)
+		} else {
+			msg = http.StatusText(code)
+		}
 	}
 
 	if code == http.StatusInternalServerError {

--- a/pkg/handler_test.go
+++ b/pkg/handler_test.go
@@ -32,9 +32,9 @@ func TestHandler(t *testing.T) {
 		assert.Contains(tt, rr.Body.String(), "Internal Server Error", "expected generic errors to have the correct message")
 	})
 
-	t.Run("surfaces HTTP errors transparently but obfuscates message", func(tt *testing.T) {
+	t.Run("surfaces HTTP errors transparently", func(tt *testing.T) {
 		c, rr := test.NewContext(t, nil)
-		err := echo.NewHTTPError(http.StatusForbidden, "foo")
+		err := echo.NewHTTPError(http.StatusForbidden)
 
 		h.handleError(err, c)
 
@@ -42,34 +42,14 @@ func TestHandler(t *testing.T) {
 		assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
 	})
 
-	t.Run("overwrites HTTP 400 error messages", func(tt *testing.T) {
+	t.Run("overwrites default HTTP status codes if custom error message is provided", func(tt *testing.T) {
 		c, rr := test.NewContext(t, nil)
-		err := echo.NewHTTPError(http.StatusBadRequest, "this shouldn't be sent to customers")
+		err := echo.NewHTTPError(http.StatusBadRequest, "custom error message")
 
 		h.handleError(err, c)
 
 		assert.Equal(tt, http.StatusBadRequest, rr.Code, "expected HTTP errors to be correct")
-		assert.Contains(tt, rr.Body.String(), "Bad Request", "expected HTTP errors to have the correct message")
-	})
-
-	t.Run("overwrites HTTP 403 error messages", func(tt *testing.T) {
-		c, rr := test.NewContext(t, nil)
-		err := echo.NewHTTPError(http.StatusForbidden, "this shouldn't be sent to customers")
-
-		h.handleError(err, c)
-
-		assert.Equal(tt, http.StatusForbidden, rr.Code, "expected HTTP errors to be correct")
-		assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
-	})
-
-	t.Run("overwrites HTTP 404 error messages", func(tt *testing.T) {
-		c, rr := test.NewContext(t, nil)
-		err := echo.NewHTTPError(http.StatusNotFound, "this shouldn't be sent to customers")
-
-		h.handleError(err, c)
-
-		assert.Equal(tt, http.StatusNotFound, rr.Code, "expected HTTP errors to be correct")
-		assert.Contains(tt, rr.Body.String(), "Not Found", "expected HTTP errors to have the correct message")
+		assert.Contains(tt, rr.Body.String(), "custom error message", "expected HTTP errors to have the overwritten message")
 	})
 }
 


### PR DESCRIPTION
# What 
- [x] Set the HTTP response message to the one being set in `echo.HTTPError` instead of `https.StatusText(code)`.

# Why
Under the hood Echo already sets the `Message` property to `http.StatusText(code)` if a message is not provided (it's an optional argument to `echo.NewHTTPError(...)`. Right now we're forced to always return the HTTP status text response instead of a custom, more descriptive message. For example, we might want to return `"postcard not found"` instead of simply returning `"not found"`. This change allows us to do that.

It seems that previously we were always discarding the messages that were attached to the HTTPError. I think this might have been a bug from when we ported over the code from assets-proxy where we wanted to obscure the errors messages for security purposes as an extra security measure. If this seems wrong, please let me know!