### PR TITLE
fix(logging): Only log stack traces for server errors

### DIFF
--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -61,8 +61,14 @@ func (h *handler) handleError(err error, c echo.Context) {
 		h.reporter.Report(err, c.Request())
 	}
 
-	log.Root(logger.Data{"status_code": code}).Err(err).Error("request error")
+	log = log.Root(logger.Data{"status_code": code})
+	if code >= 500 {
+		// we only call .Err() if we want to include the stack trace in the log
+		log = log.Err(err)
+	}
+	log.Error("request error")
 
+	// format the error as JSON for the middleware response
 	err = c.JSON(code, map[string]interface{}{"error": map[string]interface{}{"message": msg, "status_code": code}})
 	if err != nil {
 		log.Err(err).Error("error handler json error")


### PR DESCRIPTION
We've noticed that go projects configured for Sentry log the stack
trace of every error returned by a handler. This includes "errors"
that are completely normal, such as 401s, 404s, etc. This is the
result of calling `.Err()` on the logger, which captures the stack.

This commit changes this behavior to only call `.Err()` on an
actual server error; that is, a 5xx status or a non-HTTP error.